### PR TITLE
Fix the double hop case

### DIFF
--- a/ConstructorGenerator.Attributes/ConstructorGenerator.Attributes.csproj
+++ b/ConstructorGenerator.Attributes/ConstructorGenerator.Attributes.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>
-        <Version>0.5.4</Version>
+        <Version>0.5.5</Version>
     </PropertyGroup>
 
 </Project>

--- a/ConstructorGenerator/ConstructorGenerator.csproj
+++ b/ConstructorGenerator/ConstructorGenerator.csproj
@@ -9,7 +9,7 @@
     <RepositoryUrl>https://github.com/Swarley97/ConstructorGenerator</RepositoryUrl>
     <PackageTags>generator; c#; constructor</PackageTags>
     <PackageProjectUrl>https://github.com/Swarley97/ConstructorGenerator</PackageProjectUrl>
-    <Version>0.5.4</Version>
+    <Version>0.5.5</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/Sandbox/ClassWithDependency.cs
+++ b/Sandbox/ClassWithDependency.cs
@@ -49,3 +49,26 @@ internal partial class Test : Base
 
     public string ComputedProperty => string.Empty;
 }
+
+
+internal class VeryBaseClass
+{
+    private readonly string _baseDependency;
+
+    public VeryBaseClass(string baseDependency)
+    {
+        _baseDependency = baseDependency;
+    }
+}
+
+[GenerateFullConstructor]
+internal partial class IntermediateClass : VeryBaseClass
+{
+    private readonly int _ownDependency;
+}
+
+[GenerateFullConstructor]
+internal partial class FinalClass : IntermediateClass
+{
+    
+}


### PR DESCRIPTION
When generating constructors in a class hierarchy, base constructor parameters have not been bubbling up correctly. Also optimized the generation order and made sure no double scanning is necessary.