### PR TITLE
Feature/deduplication

### DIFF
--- a/ConstructorGenerator.Tests/TestClasses/BaseClassWithFullConstructorAttribute.cs
+++ b/ConstructorGenerator.Tests/TestClasses/BaseClassWithFullConstructorAttribute.cs
@@ -7,6 +7,10 @@ public partial class BaseClassWithFullConstructorAttribute
 {
     public string BaseAProperty { get; }
 
+    // ReSharper disable once NotAccessedField.Local
+    // ReSharper disable once InconsistentNaming
+    private readonly string BaseDuplicateNameField;
+
     [ConstructorDependency]
     public string BaseBField;
 }

--- a/ConstructorGenerator.Tests/TestClasses/TestClassWithBaseClassAndFullConstructorAttribute.cs
+++ b/ConstructorGenerator.Tests/TestClasses/TestClassWithBaseClassAndFullConstructorAttribute.cs
@@ -27,4 +27,9 @@ public partial class TestClassWithBaseClassAndFullConstructorAttribute : BaseCla
     
     [ExcludeConstructorDependency]
     public string? PropertyReadOnlyButIgnored { get; }
+    
+    
+    // ReSharper disable once NotAccessedField.Local
+    // ReSharper disable once InconsistentNaming
+    private readonly string BaseDuplicateNameField;
 }

--- a/ConstructorGenerator.Tests/Tests.cs
+++ b/ConstructorGenerator.Tests/Tests.cs
@@ -15,7 +15,9 @@ public class Tests
                 "propertyWithSetterButAttribute",
                 "readonlyDependency",
                 "notInitNameReadOnly",
+                "duplicate",
                 "baseA",
+                "duplicate",
                 "baseB");
         
         Assert.Multiple(() =>
@@ -62,7 +64,7 @@ public class Tests
     [Test]
     public void When_Class_With_Base_And_GenerateBaseConstructorCallAttribute()
     {
-        TestClassWithBaseButNoDependencies testClass = new("baseA", "baseB");
+        TestClassWithBaseButNoDependencies testClass = new("baseA", "duplicate","baseB");
         Assert.Multiple(() =>
         {
             Assert.That(testClass.BaseAProperty, Is.EqualTo("baseA"));

--- a/ConstructorGenerator/ConstructorGenerator.csproj
+++ b/ConstructorGenerator/ConstructorGenerator.csproj
@@ -10,7 +10,7 @@
     <PackageTags>generator; c#; constructor</PackageTags>
     <PackageProjectUrl>https://github.com/Swarley97/ConstructorGenerator</PackageProjectUrl>
     <IsDevelopmentDependency>true</IsDevelopmentDependency>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/ConstructorGenerator/Generation/GenerateConstructorTask.cs
+++ b/ConstructorGenerator/Generation/GenerateConstructorTask.cs
@@ -104,13 +104,36 @@ internal class GenerateConstructorTask
             index++;
         }
 
-        return new GenerateParameterList(parameters.Concat(baseParameter).ToList(),
+        List<GenerateParameter> allParameters = parameters.Concat(baseParameter).ToList();
+        DeDuplicateNames(allParameters);
+        return new GenerateParameterList(allParameters,
                                          baseParameter, parameters);
+    }
+    
+    
+    private void DeDuplicateNames(IReadOnlyCollection<GenerateParameter> allParameters)
+    {
+        foreach (GenerateParameter parameter in allParameters)
+        {
+            string baseName = parameter.Name;
+            string workingName = baseName;
+            int counter = 1;
+            while (allParameters.Count(x => x.Name == workingName) >= 2)
+            {
+                workingName = $"{baseName}{counter}";
+                counter++;
+            }
+
+            parameter.Name = workingName;
+        }
     }
 
     private record GenerateParameterList(IReadOnlyList<GenerateParameter> AllParameters,
                                          IReadOnlyList<GenerateParameter> BaseParameters,
                                          IReadOnlyList<GenerateParameter> Parameters);
 
-    private record GenerateParameter(string Type, string Name, bool IsOptional, ParameterInfo Origin);
+    private record GenerateParameter(string Type, string Name, bool IsOptional, ParameterInfo Origin)
+    {
+        public string Name { get; set; } = Name;
+    }
 }


### PR DESCRIPTION
If a class had the same member name as the base class, invalid code was being generated.